### PR TITLE
Add separate logging for Indexer, Database, Vectoriser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -179,6 +194,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chrono"
+version = "0.4.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "num-traits",
+ "windows-link",
+]
+
+[[package]]
 name = "clang-sys"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -293,6 +320,22 @@ name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "flexi_logger"
+version = "0.27.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469e584c031833564840fb0cdbce99bdfe946fd45480a188545e73a76f45461c"
+dependencies = [
+ "chrono",
+ "glob",
+ "is-terminal",
+ "lazy_static",
+ "log",
+ "nu-ansi-term",
+ "regex",
+ "thiserror",
+]
 
 [[package]]
 name = "fnv"
@@ -451,6 +494,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -567,6 +616,30 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -723,6 +796,17 @@ name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "itertools"
@@ -931,6 +1015,24 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.49.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c073d3c1930d0751774acf49e66653acecb416c3a54c6ec095a9b11caddb5a68"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -1526,6 +1628,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1689,8 +1811,11 @@ dependencies = [
  "bytes",
  "bytevec",
  "dotenv",
+ "flexi_logger",
  "hex",
+ "log",
  "nix",
+ "once_cell",
  "prost",
  "prost-build",
  "prost-types",
@@ -1815,6 +1940,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings 0.4.2",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1827,7 +1987,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
 dependencies = [
  "windows-result",
- "windows-strings",
+ "windows-strings 0.3.1",
  "windows-targets 0.53.0",
 ]
 
@@ -1850,6 +2010,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1865,6 +2043,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -1901,6 +2094,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -1913,6 +2112,12 @@ checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -1922,6 +2127,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1949,6 +2160,12 @@ checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -1958,6 +2175,12 @@ name = "windows_i686_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1973,6 +2196,12 @@ checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -1982,6 +2211,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,9 @@ prost = "0.13.5"
 prost-types = "0.13.5"
 bytes = "1.10.1"
 nix = "0.30.1"
+flexi_logger = "0.27"    
+log = "0.4"           
+once_cell = "1.18"
 
 [build-dependencies]
 prost-build = "0.13.5"

--- a/database/db.rs
+++ b/database/db.rs
@@ -1,10 +1,11 @@
 use crate::database::db_thread;
 use crate::database::keygen::*;
 use crate::database::types::Data;
-use hex::{decode, FromHexError as hexerr};
-use rocksdb::backup::{BackupEngine, BackupEngineOptions, RestoreOptions};
-use rocksdb::{DBWithThreadMode, Error as err, IteratorMode, Options, SingleThreaded, DB};
-use sha2::{Digest, Sha256};
+use hex::{ decode, FromHexError as hexerr };
+use rocksdb::backup::{ BackupEngine, BackupEngineOptions, RestoreOptions };
+use rocksdb::{ DBWithThreadMode, Error as err, IteratorMode, Options, SingleThreaded, DB };
+use sha2::{ Digest, Sha256 };
+use log::{ info, warn, error, debug };
 
 pub struct Database {
     pub db: DBWithThreadMode<SingleThreaded>,
@@ -76,8 +77,13 @@ impl Database {
         let key_string = format!("{:x}", key);
         match self.db.put(&key, value.as_ref() as &[u8]) {
             Ok(_) => {
-                if let Err(e) = db_thread::add_node_pipe((key_string.clone(), data.vector.vector), 0) {
-                    eprintln!("Failed to add node to pipe: {}", e);
+                if
+                    let Err(e) = db_thread::add_node_pipe(
+                        (key_string.clone(), data.vector.vector),
+                        0
+                    )
+                {
+                    error!("Failed to add node to pipe: {}", e);
                     // Optionally, you could return an error here instead of just logging it
                 }
                 return Ok(key_string);
@@ -110,7 +116,7 @@ impl Database {
         match self.db.get(&key) {
             Ok(Some(_)) => {
                 if let Err(e) = db_thread::delete_node_pipe(key_string) {
-                    eprintln!("Failed to delete node from pipe: {}", e);
+                    error!("Failed to delete node from pipe: {}", e);
                 }
                 match self.db.delete(key) {
                     Ok(_) => Ok(Some(())),
@@ -126,7 +132,7 @@ impl Database {
 
     pub fn delete_from_database_with_key(
         &mut self,
-        input: &str,
+        input: &str
     ) -> Result<Result<Option<()>, err>, hexerr> {
         match decode(input) {
             Ok(bytes) => {
@@ -134,7 +140,7 @@ impl Database {
                 match self.db.get(&key) {
                     Ok(Some(_)) => {
                         if let Err(e) = db_thread::delete_node_pipe(input.to_string()) {
-                            eprintln!("Failed to delete node from pipe: {}", e);
+                            error!("Failed to delete node from pipe: {}", e);
                         }
                         match self.db.delete(key) {
                             Ok(_) => Ok(Ok(Some(()))),
@@ -176,15 +182,15 @@ impl Database {
         &self,
         k_type: u8,
         k_value: usize,
-        givenvec: Vec<f32>,
+        givenvec: Vec<f32>
     ) -> Result<String, String> {
         // Convert all this data to a string and call the pipe function
         match db_thread::get_knn_pipe(k_type, k_value, givenvec) {
             Ok(_) => {
-                return Ok(format!("Finding knn...",));
+                return Ok(format!("Finding knn..."));
             }
             Err(e) => {
-                eprintln!("Failed to write to named pipe: {}", e);
+                error!("Failed to write to named pipe: {}", e);
                 return Err(format!("Failed to write to named pipe: {}", e));
             }
         }
@@ -193,16 +199,19 @@ impl Database {
     pub fn sync_with_indexer(&self) {
         // iterate through the database and send the data to the indexer
         let iter = self.db.iterator(IteratorMode::Start); //iterates from the start
-        println!("Syncing database with indexer...");
+        info!("Syncing database with indexer...");
         for item in iter {
             let (key, value) = item.unwrap();
-            let hex_strings: Vec<String> = key.iter().map(|b| format!("{:02x}", b)).collect();
+            let hex_strings: Vec<String> = key
+                .iter()
+                .map(|b| format!("{:02x}", b))
+                .collect();
             let result = hex_strings.join("");
             let vec = deserialize(&value);
             if let Err(e) = db_thread::add_node_pipe((result, vec.vector.vector), 0) {
-                eprintln!("Failed to add node to pipe during sync: {}", e);
+                error!("Failed to add node to pipe during sync: {}", e);
             }
         }
-        println!("Syncing complete.");
+        info!("Syncing complete.");
     }
 }

--- a/database/db_thread.rs
+++ b/database/db_thread.rs
@@ -1,11 +1,17 @@
 use crate::indexer::proto::indexer_thread::{
-    AddNode, Command, DeleteNode, GetKnn, PrintTree, Vector,
+    AddNode,
+    Command,
+    DeleteNode,
+    GetKnn,
+    PrintTree,
+    Vector,
 };
 use prost::Message;
 use std::cell::RefCell;
 use std::fs::OpenOptions;
 use std::io::prelude::*;
 use std::sync::Once;
+use log::error;
 
 static INIT_PIPE: Once = Once::new();
 thread_local! {
@@ -25,7 +31,7 @@ fn get_pipe_writer() -> std::io::Result<std::fs::File> {
                 OpenOptions::new()
                     .write(true)
                     .open(PIPE_PATH)
-                    .expect("Failed to open named pipe for writing:"),
+                    .expect("Failed to open named pipe for writing:")
             );
         }
         result = Some(pipe.borrow().as_ref().unwrap().try_clone());
@@ -42,9 +48,7 @@ fn write_protobuf_to_pipe<T: Message>(message: &T) -> std::io::Result<()> {
 
     // Serialize the protobuf message
     let mut buf = Vec::new();
-    message
-        .encode(&mut buf)
-        .expect("Failed to encode protobuf message");
+    message.encode(&mut buf).expect("Failed to encode protobuf message");
 
     let msg_size = buf.len() as u32;
     let size_bytes = msg_size.to_le_bytes();
@@ -57,6 +61,7 @@ fn write_protobuf_to_pipe<T: Message>(message: &T) -> std::io::Result<()> {
 }
 
 pub fn add_node_pipe(data: (String, Vec<f32>), depth: usize) -> std::io::Result<()> {
+    init_module_logger!("database");
     // Create the Vector protobuf message
     let vector = Vector { values: data.1 };
 
@@ -74,7 +79,7 @@ pub fn add_node_pipe(data: (String, Vec<f32>), depth: usize) -> std::io::Result<
 
     // Write the command to the pipe
     if let Err(e) = write_protobuf_to_pipe(&command) {
-        eprintln!("Failed to write to named pipe: {}", e);
+        error!("Failed to write to named pipe: {}", e);
         return Err(e);
     }
 
@@ -88,13 +93,13 @@ pub fn delete_node_pipe(data: String) -> std::io::Result<()> {
     // Create the Command protobuf message
     let command = Command {
         command: Some(
-            crate::indexer::proto::indexer_thread::command::Command::DeleteNode(delete_node),
+            crate::indexer::proto::indexer_thread::command::Command::DeleteNode(delete_node)
         ),
     };
 
     // Write the command to the pipe
     if let Err(e) = write_protobuf_to_pipe(&command) {
-        eprintln!("Failed to write to named pipe: {}", e);
+        error!("Failed to write to named pipe: {}", e);
         return Err(e);
     }
 
@@ -121,7 +126,7 @@ pub fn get_knn_pipe(knn_type: u8, k_value: usize, vector_data: Vec<f32>) -> std:
 
     // Write the command to the pipe
     if let Err(e) = write_protobuf_to_pipe(&command) {
-        eprintln!("Failed to write to named pipe: {}", e);
+        error!("Failed to write to named pipe: {}", e);
         return Err(e);
     }
 
@@ -135,13 +140,13 @@ pub fn print_tree_debug_pipe() -> std::io::Result<()> {
     // Create the Command protobuf message
     let command = Command {
         command: Some(
-            crate::indexer::proto::indexer_thread::command::Command::PrintTree(print_tree),
+            crate::indexer::proto::indexer_thread::command::Command::PrintTree(print_tree)
         ),
     };
 
     // Write the command to the pipe
     if let Err(e) = write_protobuf_to_pipe(&command) {
-        eprintln!("Failed to write to named pipe: {}", e);
+        error!("Failed to write to named pipe: {}", e);
         return Err(e);
     }
 

--- a/indexer/indexing.rs
+++ b/indexer/indexing.rs
@@ -1,17 +1,19 @@
 // use crate::database::db::Database;
-use crate::indexer::proto::indexer_thread::{Command, KnnType as ProtoKnnType};
+use crate::indexer::proto::indexer_thread::{ Command, KnnType as ProtoKnnType };
 use core::f32;
 use prost::Message;
 use std::cmp::Ordering;
 use std::collections::BinaryHeap;
 use std::fs::OpenOptions;
-use std::io::{BufReader, Read};
+use std::io::{ BufReader, Read };
 use std::os::unix::fs::FileTypeExt;
+use log::{ info, warn, error, debug };
 
 const PIPE_PATH: &str = "/tmp/db_pipe";
 
 // Ensure the pipe directory exists
 pub fn ensure_pipe_exists() -> std::io::Result<()> {
+    init_module_logger!("indexer");
     if let Some(parent) = std::path::Path::new(PIPE_PATH).parent() {
         std::fs::create_dir_all(parent)?;
     }
@@ -82,16 +84,26 @@ pub fn distance(a: Vec<f32>, b: Vec<f32>, dist_type: KNNType) -> f32 {
             let score: Vec<f32> = a
                 .iter()
                 .zip(b.iter())
-                .map(|(&x, &y)| (if x != y { 1f32 } else { 0f32 }))
+                .map(|(&x, &y)| if x != y { 1f32 } else { 0f32 })
                 .collect();
             return score.iter().sum::<f32>();
         }
         KNNType::Cosine => {
-            let p_score: Vec<f32> = a.iter().zip(b.iter()).map(|(&x, &y)| x * y).collect();
+            let p_score: Vec<f32> = a
+                .iter()
+                .zip(b.iter())
+                .map(|(&x, &y)| x * y)
+                .collect();
             let p = p_score.iter().sum::<f32>();
-            let q_score: Vec<f32> = a.iter().map(|&n| n * n).collect();
+            let q_score: Vec<f32> = a
+                .iter()
+                .map(|&n| n * n)
+                .collect();
             let q = q_score.iter().sum::<f32>().sqrt();
-            let r_score: Vec<f32> = b.iter().map(|&n| n * n).collect();
+            let r_score: Vec<f32> = b
+                .iter()
+                .map(|&n| n * n)
+                .collect();
             let r = r_score.iter().sum::<f32>().sqrt();
             return p / (q * r);
         }
@@ -99,9 +111,7 @@ pub fn distance(a: Vec<f32>, b: Vec<f32>, dist_type: KNNType) -> f32 {
 }
 
 pub trait Indexer {
-    fn new() -> Self
-    where
-        Self: Sized;
+    fn new() -> Self where Self: Sized;
     fn add_node(&mut self, data: (String, Vec<f32>), depth: usize);
     fn delete_node(&mut self, data: String);
     fn print_tree_for_debug(&self);
@@ -111,23 +121,25 @@ pub trait Indexer {
     fn db_thread(&mut self) {
         // Ensure the pipe exists before opening it
         if let Err(e) = ensure_pipe_exists() {
-            eprintln!("Failed to create pipe: {}", e);
+            error!("Failed to create pipe: {}", e);
             return;
         }
-        
+
         let pipe = match OpenOptions::new().read(true).open(PIPE_PATH) {
             Ok(pipe) => {
                 // Check if the file is a named pipe
-                let metadata = std::fs::metadata(PIPE_PATH)
+                let metadata = std::fs
+                    ::metadata(PIPE_PATH)
                     .expect("Unable to fetch metadata for the named pipe");
                 if !metadata.file_type().is_fifo() {
-                    eprintln!("The path is not a named pipe");
+                    error!("The path '{}' is not a named pipe", PIPE_PATH);
                     return;
                 }
+                info!("Successfully opened named pipe: {}", PIPE_PATH);
                 pipe
             }
             Err(e) => {
-                eprintln!("Failed to open pipe: {}", e);
+                error!("Failed to open pipe: {}", e);
                 return;
             }
         };
@@ -141,13 +153,14 @@ pub trait Indexer {
             match reader.read_exact(&mut size_buf) {
                 Ok(_) => {}
                 Err(e) => {
-                    eprintln!("Failed to read message size: {}", e);
+                    error!("Failed to read message size: {}", e);
                     break;
                 }
             }
 
             // Convert bytes to u32 (size of the message)
             let msg_size = u32::from_le_bytes(size_buf) as usize;
+            debug!("Reading message of size: {}", msg_size);
 
             // Prepare buffer
             buffer.clear();
@@ -155,9 +168,11 @@ pub trait Indexer {
 
             // Read the actual message
             match reader.read_exact(&mut buffer) {
-                Ok(_) => {}
+                Ok(_) => {
+                    debug!("Successfully read protobuf message of size: {}", msg_size);
+                }
                 Err(e) => {
-                    eprintln!("Failed to read message: {}", e);
+                    error!("Failed to read protobuf message: {}", e);
                     break;
                 }
             }
@@ -166,14 +181,24 @@ pub trait Indexer {
             match Command::decode(&buffer[..]) {
                 Ok(command) => {
                     match command.command {
-                        Some(crate::indexer::proto::indexer_thread::command::Command::AddNode(
-                            add_node,
-                        )) => {
+                        Some(
+                            crate::indexer::proto::indexer_thread::command::Command::AddNode(
+                                add_node,
+                            ),
+                        ) => {
                             if let Some(vector) = add_node.vector {
                                 let depth = add_node.depth as usize;
                                 let key = add_node.key;
                                 let values = vector.values;
+                                info!(
+                                    "Received AddNode command: key = {}, depth = {}, vector_len = {}",
+                                    key,
+                                    depth,
+                                    values.len()
+                                );
                                 self.add_node((key, values), depth);
+                            } else {
+                                warn!("AddNode command received with empty vector");
                             }
                         }
                         Some(
@@ -182,29 +207,38 @@ pub trait Indexer {
                             ),
                         ) => {
                             let key = delete_node.key;
+                            info!("Received DeleteNode command: key = {}", key);
                             self.delete_node(key);
                         }
-                        Some(crate::indexer::proto::indexer_thread::command::Command::GetKnn(
-                            get_knn,
-                        )) => {
+                        Some(
+                            crate::indexer::proto::indexer_thread::command::Command::GetKnn(
+                                get_knn,
+                            ),
+                        ) => {
                             if let Some(vector) = get_knn.vector {
                                 let k_value = get_knn.k_value as usize;
                                 let values = vector.values;
 
                                 // Convert protobuf enum to our enum
-                                let knn_type = match ProtoKnnType::try_from(get_knn.knn_type as i32)
+                                let knn_type = match
+                                    ProtoKnnType::try_from(get_knn.knn_type as i32)
                                 {
                                     Ok(ProtoKnnType::Euclidean) => KNNType::Euclidean,
                                     Ok(ProtoKnnType::Manhattan) => KNNType::Manhattan,
                                     Ok(ProtoKnnType::Hamming) => KNNType::Hamming,
                                     Ok(ProtoKnnType::Cosine) => KNNType::Cosine,
                                     _ => {
-                                        eprintln!("Unknown KNN type from protobuf");
+                                        warn!(
+                                            "Unknown KNN type from protobuf: {}",
+                                            get_knn.knn_type
+                                        );
                                         continue;
                                     }
                                 };
 
                                 self.get_knn(knn_type, k_value, values);
+                            } else {
+                                warn!("GetKnn command received with empty vector");
                             }
                         }
                         Some(
@@ -213,12 +247,12 @@ pub trait Indexer {
                             self.print_tree_for_debug();
                         }
                         None => {
-                            eprintln!("Received empty command");
+                            error!("Received empty command");
                         }
                     }
                 }
                 Err(e) => {
-                    eprintln!("Failed to decode protobuf message: {}", e);
+                    error!("Failed to decode protobuf message: {}", e);
                 }
             }
         }
@@ -236,6 +270,6 @@ pub trait Node {
         &'a self,
         input: Vec<f32>,
         knn_type: KNNType,
-        heap: &'a mut BinaryHeap<DataHeap>,
+        heap: &'a mut BinaryHeap<DataHeap>
     ) -> (&'a mut BinaryHeap<DataHeap>, usize);
 }

--- a/logger.rs
+++ b/logger.rs
@@ -1,0 +1,94 @@
+use flexi_logger::{ DeferredNow, LogSpecification, Logger };
+use flexi_logger::writers::LogWriter;
+use log::Record;
+use once_cell::sync::Lazy;
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::fs::{ create_dir_all, OpenOptions };
+use std::io::{ self, Write };
+use std::path::Path;
+use std::sync::{ Mutex, Once };
+
+// Cache for writers based on log target name
+static MODULE_WRITERS: Lazy<Mutex<HashMap<String, Box<dyn Write + Send>>>> = Lazy::new(|| {
+    Mutex::new(HashMap::new())
+});
+
+// Thread-local to store per-thread log file name
+thread_local! {
+    static CURRENT_LOG_TARGET: RefCell<Option<String>> = RefCell::new(None);
+}
+
+static INIT: Once = Once::new();
+
+/// Call this once per file (module) to set up logging for that file.
+/// Logs will go to logs/<name>.log
+pub fn init_logger_with_name(name: &str) {
+    // Store the log target in thread-local storage
+    CURRENT_LOG_TARGET.with(|slot| {
+        *slot.borrow_mut() = Some(name.to_string());
+    });
+
+    // Only start the logger once globally
+    INIT.call_once(|| {
+        Logger::with(LogSpecification::parse("debug").unwrap())
+            .log_to_writer(Box::new(NamedModuleWriter {}))
+            .format(custom_format)
+            .start()
+            .unwrap();
+    });
+}
+
+// The custom log format (shared for all writers)
+fn custom_format(w: &mut dyn Write, now: &mut DeferredNow, record: &Record) -> io::Result<()> {
+    write!(
+        w,
+        "[{}][{}][{}:{}] {}\n",
+        now.format("%Y-%m-%d %H:%M:%S"),
+        record.level(),
+        record.module_path().unwrap_or("unknown"),
+        record.line().unwrap_or(0),
+        &record.args()
+    )
+}
+
+// LogWriter that writes to the file specified by CURRENT_LOG_TARGET
+pub struct NamedModuleWriter;
+
+impl LogWriter for NamedModuleWriter {
+    fn write(&self, now: &mut DeferredNow, record: &Record) -> io::Result<()> {
+        let name = CURRENT_LOG_TARGET.with(|slot| {
+            slot.borrow()
+                .clone()
+                .unwrap_or_else(|| "unknown".to_string())
+        });
+
+        let mut map = MODULE_WRITERS.lock().unwrap();
+
+        let writer = map.entry(name.clone()).or_insert_with(|| {
+            let log_dir = Path::new("logs");
+            create_dir_all(log_dir).unwrap();
+
+            let file_path = log_dir.join(format!("{}.log", name));
+            let file = OpenOptions::new().create(true).append(true).open(file_path).unwrap();
+
+            Box::new(file) as Box<dyn Write + Send>
+        });
+
+        custom_format(&mut **writer, now, record)
+    }
+
+    fn flush(&self) -> io::Result<()> {
+        for writer in MODULE_WRITERS.lock().unwrap().values_mut() {
+            writer.flush()?;
+        }
+        Ok(())
+    }
+}
+
+#[macro_export]
+macro_rules! init_module_logger {
+    ($name:expr) => {
+        crate::logger::init_logger_with_name($name)
+    };
+}

--- a/main.rs
+++ b/main.rs
@@ -1,3 +1,6 @@
+#[macro_use]
+mod logger;
+
 mod cli;
 mod database;
 mod indexer;
@@ -5,8 +8,13 @@ mod testing;
 mod vectorisers;
 // use std::{thread, time::Duration};
 
-// use vectorisers::vectoriser::read_from_named_pipe;
+use log::info;
+
 fn main() {
+    init_module_logger!("main");
+    info!("Starting application...");
+
+    // Simulate logger presence in commented out threading
     // thread::spawn(move || {
     //     loop {
     //         read_from_named_pipe();
@@ -15,6 +23,7 @@ fn main() {
     // });
 
     println!("Main thread is running");
+    info!("Main thread reached CLI");
 
     cli::run_cli();
 }

--- a/vectorisers/vectoriser.rs
+++ b/vectorisers/vectoriser.rs
@@ -1,5 +1,8 @@
+use log::{ debug, error, info, warn };
+
 use reqwest::blocking::Client;
-use serde_derive::{Deserialize, Serialize};
+use serde_derive::{ Deserialize, Serialize };
+
 // use std::collections::HashMap;
 // use std::fs::File;
 // use std::io::{BufReader, BufRead};
@@ -21,21 +24,24 @@ pub struct VectorResponse {
 
 #[cfg(feature = "test_vectors")]
 pub fn vectorise(input: &str, _pooling_strategy: &str) -> VectorResponse {
-    println!("Using test vectoriser with fixed size vectors");
+    init_module_logger!("vectoriser");
+    info!("Using test vectoriser with fixed size vectors");
     // Generate a deterministic vector of size 10 based on the input
     let mut hash: u64 = 0;
     for byte in input.bytes() {
         hash = hash.wrapping_mul(31).wrapping_add(byte as u64);
     }
-    
+
     // Create a fixed-size vector of 10 elements
     let vector: Vec<f32> = (0..10)
         .map(|i| {
             // Use the hash and position to generate a deterministic value
-            let value = ((hash + i as u64) % 100) as f32 / 100.0;
+            let value = (((hash + (i as u64)) % 100) as f32) / 100.0;
             value
         })
         .collect();
+
+    debug!("Generated test vector: {:?}", vector);
 
     VectorResponse {
         text: input.to_string(),
@@ -45,19 +51,36 @@ pub fn vectorise(input: &str, _pooling_strategy: &str) -> VectorResponse {
 
 #[cfg(not(feature = "test_vectors"))]
 pub fn vectorise(input: &str, pooling_strategy: &str) -> VectorResponse {
+    init_module_logger!("vectoriser");
+    info!("Sending vectorization request to API");
+
     let client = Client::new();
     let response = client
         .post("http://localhost:8000/vectorize/")
-        .json(&VectorizationRequest {
-            text: input.to_string(),
-            pooling_strategy: pooling_strategy.to_string(),
-        })
-        .send()
-        .expect("Failed to send request");
-    
-    response
-        .json::<VectorResponse>()
-        .expect("Failed to parse vector response")
+        .json(
+            &(VectorizationRequest {
+                text: input.to_string(),
+                pooling_strategy: pooling_strategy.to_string(),
+            })
+        )
+        .send();
+
+    match response {
+        Ok(resp) => {
+            info!("Request sent successfully. Status: {}", resp.status());
+            match resp.json::<VectorResponse>() {
+                Ok(vector_response) => vector_response,
+                Err(e) => {
+                    error!("Failed to parse response: {}", e);
+                    panic!("Vector response parsing failed");
+                }
+            }
+        }
+        Err(e) => {
+            error!("Failed to send request: {}", e);
+            panic!("Vector request failed");
+        }
+    }
 }
 
 // // Reads from the named pipe and processes the vector


### PR DESCRIPTION
This PR implements component-specific logging using `flexi_logger`.

- Logs now go into:
  - `logs/indexer.log`
  - `logs/database.log`
  - `logs/vectoriser.log`

- Added macro `init_module_logger!()` for convenient usage inside each module.

Closes #15