### PR TITLE
Switch cosine to 1-cos distance

### DIFF
--- a/crates/index/src/flat.rs
+++ b/crates/index/src/flat.rs
@@ -54,15 +54,7 @@ impl VectorIndex for FlatIndex {
             })
             .collect::<Vec<_>>();
 
-        // Sorting logic according to type of metric used
-        match similarity {
-            Similarity::Euclidean | Similarity::Manhattan | Similarity::Hamming => {
-                scores.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap());
-            }
-            Similarity::Cosine => {
-                scores.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
-            }
-        }
+        scores.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap());
 
         Ok(scores
             .into_iter()

--- a/crates/index/src/lib.rs
+++ b/crates/index/src/lib.rs
@@ -53,7 +53,7 @@ pub fn distance(a: DenseVector, b: DenseVector, dist_type: Similarity) -> f32 {
             let q = q_score.iter().sum::<f32>().sqrt();
             let r_score: Vec<f32> = b.iter().map(|&n| n * n).collect();
             let r = r_score.iter().sum::<f32>().sqrt();
-            p / (q * r)
+            1.0 - (p / (q * r))
         }
     }
 }


### PR DESCRIPTION
This was previously returning the distances for `Euclidean, Manhattan, Hamming`, and similarity for `cosine`
`pub fn distance(a: DenseVector, b: DenseVector, dist_type: Similarity) -> f32 {`

Fixed cosine to 1- similarity to return the distance as well.