### PR TITLE
Add protoc install step in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Check Code Formatting
         run: cargo fmt --all -- --check
 
+      - name: Install protoc for gRPC server
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler 
+
       - name: Run Clippy (Linter)
         run: cargo clippy --all-targets --all-features -- -D warnings
 


### PR DESCRIPTION
- The gRPC server crate requires protoc to compile the .proto file during build step.

- Also, tests in the gRPC server crate cannot be run simultaneously since it spawns a new gRPC server for each test which requires the socket address to not be in use. This requires the tests to be run in a single thread.